### PR TITLE
fixed: the length and width of data fifo in ps2_kbd was wrong

### DIFF
--- a/ps2_kbd.v
+++ b/ps2_kbd.v
@@ -9,7 +9,7 @@ module ps2_kbd (input clk,
   
   reg [3:0] count;     // count ps2_data bits, internal signal, for test
   reg [9:0] buffer;     // ps2_data bits
-  reg [31:0] fifo[7:0];   // data fifo
+  reg [7:0] fifo[31:0];   // data fifo
   reg [4:0] w_ptr, r_ptr;  // fifo write and read pointers
   
   always @ (negedge ps2_clk) begin


### PR DESCRIPTION
the length and width of data fifo in ps2_kbd was wrong。

expected 32 * 8bits, but got 8 * 32bits.